### PR TITLE
Add QIP-55 SHAKE256 address checksum

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,12 @@ QRL addresses are commonly displayed with a leading "Q" prefix followed by the h
 encoded address bytes. This is a convention across legacy and modern tooling,
 but not every API in this library emits the "Q" prefix directly.
 
+Modern 64-byte addresses can also be displayed with an EIP-55-style mixed-case
+checksum using `wallet/common.ToChecksumAddress`. The checksum uses SHAKE256
+instead of Keccak and changes only letter casing; the underlying address bytes
+remain unchanged. Lowercase and uppercase forms are still accepted for
+compatibility, while mixed-case input must match the checksum.
+
 ---
 
 ## Thread Safety

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -177,9 +177,9 @@ QRL v2.0 addresses are 64 bytes, derived as:
 Address = SHAKE256(Descriptor || PK)[:64]
 ```
 
-The 64-byte (512-bit) address exceeds **NIST Category 5** post-quantum collision resistance. NIST Category 5 targets 256-bit classical / 128-bit quantum security; the previous 48-byte (384-bit) size met that target and the 64-byte size provides additional headroom so the address never becomes the weakest link in the security chain (the underlying signature schemes — ML-DSA-87 and SPHINCS+-256s — both target NIST Level 5).
+The 64-byte (512-bit) address provides **NIST Category 5** post-quantum collision resistance with margin. A shorter address (e.g. 20 bytes / 160 bits) would reduce collision resistance below the security level of the underlying signature schemes (ML-DSA-87 and SPHINCS+-256s both target NIST Level 5). The 64-byte size ensures the address does not become the weakest link in the security chain.
 
-String form: `"Q" + hex(address)` = 129 characters.
+String form: `"Q" + hex(address)` = 129 characters. Display code may render the same address with an EIP-55-style mixed-case checksum using SHAKE256 over the lowercase ASCII hex address body; this changes only casing, not address bytes.
 
 ---
 

--- a/wallet/common/address.go
+++ b/wallet/common/address.go
@@ -3,6 +3,8 @@ package common
 import (
 	"encoding/hex"
 	"fmt"
+	"strings"
+	"unicode"
 
 	"github.com/theQRL/go-qrllib/wallet/common/descriptor"
 	"github.com/theQRL/go-qrllib/wallet/common/wallettype"
@@ -67,21 +69,84 @@ func expectedPKSize(desc descriptor.Descriptor) (int, error) {
 	}
 }
 
+// ToChecksumAddress returns the EIP-55-style mixed-case representation of a QRL
+// address using SHAKE256 instead of Keccak. Lowercase address strings remain the
+// canonical non-checksummed form; this helper is intended for display and typo
+// detection.
+func ToChecksumAddress(addr string) (string, error) {
+	body, err := addressBody(addr)
+	if err != nil {
+		return "", err
+	}
+
+	lowerBody := strings.ToLower(body)
+	hash := shake256ASCIIHex(lowerBody)
+	hashHex := hex.EncodeToString(hash)
+
+	var checksummed strings.Builder
+	checksummed.Grow(1 + len(lowerBody))
+	checksummed.WriteByte('Q')
+
+	for i, char := range lowerBody {
+		if char >= 'a' && char <= 'f' && hashHex[i] >= '8' {
+			checksummed.WriteRune(unicode.ToUpper(char))
+			continue
+		}
+		checksummed.WriteRune(char)
+	}
+
+	return checksummed.String(), nil
+}
+
+// IsValidChecksumAddress validates a checksummed QRL address. All-lowercase and
+// all-uppercase addresses are accepted as non-checksummed compatibility forms,
+// matching the common EIP-55 validation policy. Mixed-case addresses must match
+// the SHAKE256 checksum exactly.
+func IsValidChecksumAddress(addr string) bool {
+	body, err := addressBody(addr)
+	if err != nil {
+		return false
+	}
+	if body == strings.ToLower(body) || body == strings.ToUpper(body) {
+		return true
+	}
+
+	checksummed, err := ToChecksumAddress(addr)
+	if err != nil {
+		return false
+	}
+	return addr == checksummed
+}
+
 // IsValidAddress validates a QRL address string.
 // A valid address has the format "Q" followed by AddressSize*2 hex characters.
+// Lowercase and uppercase inputs are accepted as non-checksummed compatibility
+// forms; mixed-case inputs must pass the SHAKE256 checksum.
 func IsValidAddress(addr string) bool {
-	// Check length: "Q" prefix + hex-encoded address (2 chars per byte)
+	return IsValidChecksumAddress(addr)
+}
+
+func addressBody(addr string) (string, error) {
 	expectedLen := 1 + AddressSize*2
 	if len(addr) != expectedLen {
-		return false
+		return "", fmt.Errorf("address must be %d characters", expectedLen)
 	}
-
-	// Check Q prefix
 	if addr[0] != 'Q' {
-		return false
+		return "", fmt.Errorf("address must start with Q")
 	}
 
-	// Check that the rest is valid hex
-	_, err := hex.DecodeString(addr[1:])
-	return err == nil
+	body := addr[1:]
+	if _, err := hex.DecodeString(body); err != nil {
+		return "", fmt.Errorf("address contains invalid hex: %w", err)
+	}
+	return body, nil
+}
+
+func shake256ASCIIHex(body string) []byte {
+	sh := sha3.NewShake256()
+	_, _ = sh.Write([]byte(body))
+
+	hash := make([]byte, AddressSize)
+	_, _ = sh.Read(hash)
+	return hash
 }

--- a/wallet/common/address_test.go
+++ b/wallet/common/address_test.go
@@ -28,9 +28,9 @@ func TestIsValidAddress(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "valid address with mixed case hex",
+			name:     "invalid address with wrong mixed-case checksum",
 			addr:     "Q" + strings.Repeat("aB", AddressSize),
-			expected: true,
+			expected: false,
 		},
 		{
 			name:     "invalid - missing Q prefix",
@@ -80,6 +80,106 @@ func TestIsValidAddress(t *testing.T) {
 				t.Errorf("IsValidAddress(%q) = %v, want %v", tt.addr, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestToChecksumAddress(t *testing.T) {
+	lowerAddr := "Q" + strings.Repeat("ab", AddressSize)
+
+	checksummed, err := ToChecksumAddress(lowerAddr)
+	if err != nil {
+		t.Fatalf("ToChecksumAddress returned error: %v", err)
+	}
+	if len(checksummed) != len(lowerAddr) {
+		t.Fatalf("checksummed address length = %d, want %d", len(checksummed), len(lowerAddr))
+	}
+	if checksummed[0] != 'Q' {
+		t.Fatalf("checksummed address prefix = %q, want Q", checksummed[0])
+	}
+	if strings.ToLower(checksummed[1:]) != lowerAddr[1:] {
+		t.Fatalf("checksummed address changed address bytes: %s", checksummed)
+	}
+	if checksummed == lowerAddr {
+		t.Fatalf("checksummed address should use mixed case for this vector")
+	}
+}
+
+func TestIsValidChecksumAddress(t *testing.T) {
+	lowerAddr := "Q" + strings.Repeat("ab", AddressSize)
+	upperAddr := "Q" + strings.Repeat("AB", AddressSize)
+	checksummed, err := ToChecksumAddress(lowerAddr)
+	if err != nil {
+		t.Fatalf("ToChecksumAddress returned error: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		addr     string
+		expected bool
+	}{
+		{
+			name:     "lowercase compatibility form",
+			addr:     lowerAddr,
+			expected: true,
+		},
+		{
+			name:     "uppercase compatibility form",
+			addr:     upperAddr,
+			expected: true,
+		},
+		{
+			name:     "valid checksum",
+			addr:     checksummed,
+			expected: true,
+		},
+		{
+			name:     "invalid mixed case checksum",
+			addr:     "Q" + strings.Repeat("aB", AddressSize),
+			expected: false,
+		},
+		{
+			name:     "invalid prefix",
+			addr:     "q" + strings.Repeat("ab", AddressSize),
+			expected: false,
+		},
+		{
+			name:     "invalid hex",
+			addr:     "Q" + strings.Repeat("ab", AddressSize-1) + "zz",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsValidChecksumAddress(tt.addr); got != tt.expected {
+				t.Errorf("IsValidChecksumAddress(%q) = %v, want %v", tt.addr, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestChecksumAddressDetectsTypos(t *testing.T) {
+	lowerAddr := "Q" + strings.Repeat("ab", AddressSize)
+	checksummed, err := ToChecksumAddress(lowerAddr)
+	if err != nil {
+		t.Fatalf("ToChecksumAddress returned error: %v", err)
+	}
+
+	tampered := []byte(checksummed)
+	for i := 1; i < len(tampered); i++ {
+		if tampered[i] >= 'a' && tampered[i] <= 'f' {
+			tampered[i] = byte(strings.ToUpper(string(tampered[i]))[0])
+			if string(tampered) != checksummed {
+				break
+			}
+		} else if tampered[i] >= 'A' && tampered[i] <= 'F' {
+			tampered[i] = byte(strings.ToLower(string(tampered[i]))[0])
+			break
+		}
+	}
+
+	if IsValidChecksumAddress(string(tampered)) {
+		t.Fatalf("tampered checksum address should be invalid: %s", string(tampered))
 	}
 }
 

--- a/wallet/common/doc.go
+++ b/wallet/common/doc.go
@@ -32,7 +32,14 @@
 //   - ML-DSA-87 and SPHINCS+-256s (byte form):
 //     SHAKE256(Descriptor || PK)[:64] (64 bytes total)
 //
-// Addresses are validated using [IsValidAddress]. For address generation:
+// Modern Q-prefixed addresses can also be rendered with an EIP-55-style
+// mixed-case checksum using [ToChecksumAddress]. The checksum uses SHAKE256 over
+// the lowercase ASCII hex address body, not Keccak. Lowercase and uppercase
+// address strings remain accepted as non-checksummed compatibility forms, while
+// mixed-case strings must match the checksum.
+//
+// Addresses are validated using [IsValidAddress]. For strict display checksum
+// validation use [IsValidChecksumAddress]. For address generation:
 //
 //   - Use [GetAddress] for untrusted inputs (validates descriptor and pk length)
 //


### PR DESCRIPTION
Adds EIP-55-style mixed-case checksum support for QRL addresses using SHAKE256 instead of Keccak.