### PR TITLE
Add deterministic ML-DSA-87 wallet signing

### DIFF
--- a/wallet/ml_dsa_87/doc.go
+++ b/wallet/ml_dsa_87/doc.go
@@ -54,6 +54,11 @@
 // [github.com/theQRL/go-qrllib/crypto/ml_dsa_87] package doc
 // "Signing Mode" section for the full discussion.
 //
+// [Wallet.SignDeterministic] is available for protocol flows and test fixtures
+// that require byte-identical signatures for the same wallet and message. It
+// uses the same descriptor-bound context as [Wallet.Sign], but delegates to the
+// crypto package's FIPS 204 deterministic signing mode.
+//
 // # Address Format
 //
 // QRL addresses are generated from the public key with a descriptor prefix using SHAKE256:

--- a/wallet/ml_dsa_87/wallet.go
+++ b/wallet/ml_dsa_87/wallet.go
@@ -200,6 +200,16 @@ func (w *Wallet) Sign(message []uint8) ([SigSize]uint8, error) {
 	return w.d.Sign(common.SigningContext(w.desc.ToDescriptor()), message)
 }
 
+// SignDeterministic produces an ML-DSA-87 signature over message using the
+// descriptor-bound signing context and FIPS 204 deterministic mode.
+//
+// Use this only when deterministic signatures are required by a protocol or
+// test fixture. General wallet signing should use [Wallet.Sign], which remains
+// hedged by default.
+func (w *Wallet) SignDeterministic(message []uint8) ([SigSize]uint8, error) {
+	return w.d.SignDeterministic(common.SigningContext(w.desc.ToDescriptor()), message)
+}
+
 // Zeroize clears sensitive key material from memory.
 // This should be called when the Wallet is no longer needed.
 func (w *Wallet) Zeroize() {

--- a/wallet/ml_dsa_87/wallet_test.go
+++ b/wallet/ml_dsa_87/wallet_test.go
@@ -273,6 +273,43 @@ func TestWallet_Sign(t *testing.T) {
 	}
 }
 
+func TestWallet_SignDeterministic(t *testing.T) {
+	for creatorName, creator := range walletCreators {
+		for _, tc := range walletTestCases {
+			t.Run(fmt.Sprintf("%s_%s", creatorName, tc.name), func(t *testing.T) {
+				w := creator(t, tc)
+				message := []byte(tc.message)
+
+				got1, err := w.SignDeterministic(message)
+				if err != nil {
+					t.Fatalf("SignDeterministic() error: %v", err)
+				}
+				got2, err := w.SignDeterministic(message)
+				if err != nil {
+					t.Fatalf("SignDeterministic() second call error: %v", err)
+				}
+				if got1 != got2 {
+					t.Fatal("SignDeterministic() produced different signatures for the same message")
+				}
+
+				pk := w.GetPK()
+				desc := w.GetDescriptor().ToDescriptor()
+				if !Verify(message, got1[:], &pk, desc) {
+					t.Fatal("SignDeterministic() produced a signature that did not verify")
+				}
+
+				want, err := w.d.SignDeterministic(common.SigningContext(desc), message)
+				if err != nil {
+					t.Fatalf("underlying SignDeterministic() error: %v", err)
+				}
+				if got1 != want {
+					t.Fatal("wallet SignDeterministic() does not match the underlying descriptor-bound signer")
+				}
+			})
+		}
+	}
+}
+
 func TestVerify(t *testing.T) {
 	for _, tc := range walletTestCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `Wallet.SignDeterministic` for ML-DSA-87 wallets.
- Delegate to the existing crypto-level deterministic ML-DSA-87 signer with the wallet descriptor-bound signing context.
- Document that normal `Wallet.Sign` remains the hedged/default signing path.

## Rationale
This exposes the deterministic signing path needed by reproducible downstream fixtures and protocol flows without taking the broader ML-DSA package restructure from #9.

Non-goals for this PR: no `ml_dsa_87` package rename, no public/internal package split, and no change to default wallet signing behavior.

## Tests
- `go test -count=1 ./wallet/ml_dsa_87`
- `go test -count=1 ./...`